### PR TITLE
Revert "Include protected classes children into BootstrapUtils.scanClasses output

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/BootstrapUtils.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/BootstrapUtils.java
@@ -80,16 +80,11 @@ public class BootstrapUtils {
                 .map(JavaClass::getName)
                 .collect(Collectors.toSet());
 
-        Set<JavaClass> children = protectedClasses.stream()
-                .flatMap(cls -> cls.getAllSubclasses().stream())
-                .filter(BootstrapUtils::notProtected)
-                .collect(Collectors.toSet());
-
+        Set<JavaClass> visited = new HashSet<>();
         Set<JavaClass> candidates = protectedClasses.stream()
-                .flatMap(cls -> allReferrers(cls, coreNames, children).stream())
+                .flatMap(cls -> allReferrers(cls, coreNames, visited).stream())
                 .filter(BootstrapUtils::notProtected)
                 .collect(Collectors.toSet());
-
         Set<String> candidatesNames = candidates.stream()
                 .map(JavaClass::getName)
                 .collect(Collectors.toCollection(TreeSet::new));


### PR DESCRIPTION
This reverts commit 2227c58c8bab42382a9a4ad5a0197b66f055eba0

The above commit was unreleased in the 2.24 branch and causing problems with bumped build.