### PR TITLE
Add Javadoc for VanillaNamedConsumer

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/function/VanillaNamedConsumer.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/function/VanillaNamedConsumer.java
@@ -6,11 +6,22 @@ import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Adapts a {@link Consumer} with a user supplied name.
+ *
+ * @param <T> type accepted by the consumer
+ */
 public final class VanillaNamedConsumer<T> implements NamedConsumer<T> {
 
     private final Consumer<T> consumer;
     private final String name;
 
+    /**
+     * Creates an instance that delegates to the given consumer and reports the provided name.
+     *
+     * @param consumer the Consumer to invoke
+     * @param name     name used when reporting
+     */
     public VanillaNamedConsumer(final Consumer<T> consumer,
                                 final String name) {
         this.consumer = requireNonNull(consumer);


### PR DESCRIPTION
## Summary
- document VanillaNamedConsumer class
- describe constructor parameters

## Testing
- `mvn -q verify` *(fails: mvn not installed)*