### PR TITLE
Document VanillaThrowingConsumer

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/function/VanillaThrowingConsumer.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/function/VanillaThrowingConsumer.java
@@ -8,10 +8,19 @@ import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Wraps a {@link ThrowingConsumer} and converts checked exceptions to
+ * {@link ThrowingConsumerException}.
+ */
 public final class VanillaThrowingConsumer<T> implements Consumer<T> {
 
     private final ThrowingConsumer<T, ?> delegate;
 
+    /**
+     * Creates a consumer that delegates to the given {@link ThrowingConsumer}.
+     *
+     * @param delegate the consumer whose checked exceptions will be converted
+     */
     public VanillaThrowingConsumer(@NotNull final ThrowingConsumer<T, ?> delegate) {
         this.delegate = requireNonNull(delegate);
     }


### PR DESCRIPTION
## Summary
- explain VanillaThrowingConsumer purpose in class Javadoc
- add Javadoc for the constructor parameter

## Testing
- `mvn -q verify` *(fails: command not found)*