### PR TITLE
Clarify package regex usage

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/RuleUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/RuleUtil.java
@@ -2,6 +2,14 @@ package net.openhft.chronicle.testframework.internal.codestructure.rules;
 
 /**
  * Utility class for sharing rule logic.
+ * <p>
+ * The {@code INTERNAL_PACKAGE_REGEX} constant matches package names that
+ * contain {@code impl} or {@code internal}. It is currently used by
+ * {@link NonInternalClassesMustNotExtendInternalClassesRuleSupplier} to
+ * ensure non-internal classes do not extend implementation classes. Other
+ * rules may reuse this expression when they need to filter out internal
+ * packages.
+ * </p>
  */
 public enum RuleUtil {
     ;


### PR DESCRIPTION
## Summary
- expand RuleUtil Javadoc to explain `INTERNAL_PACKAGE_REGEX`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*