### PR TITLE
Add package-info for internal apimetrics

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Internal implementations supporting {@link net.openhft.chronicle.testframework.apimetrics}.
+ * Classes in this package are not part of the public API and should never be referenced directly.
+ */
+package net.openhft.chronicle.testframework.internal.apimetrics;


### PR DESCRIPTION
## Summary
- add package-info for `internal.apimetrics` module

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*