### PR TITLE
Add package-info for code structure checks

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Contains components that set up and run ArchUnit based code structure tests.
+ *
+ * <p>Classes in this package supply rules used by
+ * {@link net.openhft.chronicle.testframework.internal.codestructure.CodeStructureVerifier}
+ * to assert that the code base follows the expected design. The checks include
+ * verifying bootstrap calls and preventing external classes from extending
+ * internal types.
+ *
+ * <p>The contents of this package are for internal use only and may change
+ * without notice.
+ */
+package net.openhft.chronicle.testframework.internal.codestructure;


### PR DESCRIPTION
## Summary
- document role of `internal.codestructure` package

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*