### PR TITLE
Add docs for code structure rule suppliers

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * Provides the default ArchUnit rule suppliers used by
+ * {@link net.openhft.chronicle.testframework.internal.codestructure.CodeStructureVerifier}.
+ * <p>
+ * Each class in this package implements
+ * {@link java.util.function.Supplier Supplier}&lt;{@link com.tngtech.archunit.lang.ArchRule}&gt;
+ * and defines a structural constraint. Examples include requiring a main method
+ * to invoke {@code DtoAlias.init()} and preventing non-internal classes from
+ * extending internal ones.
+ * <p>
+ * {@code CodeStructureVerifier.Builder} installs these suppliers automatically so
+ * that the resulting verifier checks the project against all supplied rules when
+ * {@link net.openhft.chronicle.testframework.internal.codestructure.CodeStructureVerifier#verify()}
+ * is called.
+ */
+package net.openhft.chronicle.testframework.internal.codestructure.rules;


### PR DESCRIPTION
## Summary
- document purpose of rule suppliers
- show how CodeStructureVerifier installs them

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*