### PR TITLE
Add package-info for internal DTO implementations

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/dto/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/dto/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Contains internal builder and tester implementations used to verify DTO behaviour.
+ * <p>
+ * The classes in this package are not part of the public API and may change
+ * without notice. They supply the default implementation of the
+ * {@link net.openhft.chronicle.testframework.dto.DtoTester} builder and tester.
+ */
+package net.openhft.chronicle.testframework.internal.dto;


### PR DESCRIPTION
## Summary
- add package-info.java for `internal.dto`

## Testing
- `mvn -q verify` *(fails: command not found)*