### PR TITLE
Add package-info for internal function package

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/function/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/function/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Provides internal implementations backing the public {@code function} package.
+ *
+ * <p>The classes within are unstable and must not be used directly.
+ */
+package net.openhft.chronicle.testframework.internal.function;


### PR DESCRIPTION
## Summary
- document internal `function` implementations

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*