### PR TITLE
Add internal network package-info

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/network/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/network/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Contains network utilities used internally by the test framework.
+ *
+ * <p>The classes in this package are not part of the public API and may
+ * change without notice.
+ */
+package net.openhft.chronicle.testframework.internal.network;


### PR DESCRIPTION
## Summary
- document internal network utilities

## Testing
- `mvn -q verify` *(fails: `mvn: command not found`)*