### PR TITLE
Add package doc for network proxy

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/network/proxy/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/network/proxy/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Provides a lightweight TCP proxy for tests.
+ *
+ * <p>The {@link net.openhft.chronicle.testframework.internal.network.proxy.TcpProxy}
+ * listens on a port and forwards bytes to an upstream address. Each connection
+ * is managed by a {@link net.openhft.chronicle.testframework.internal.network.proxy.ProxyConnection},
+ * which can pause or stop forwarding without closing the sockets.
+ *
+ * <p>Classes in this package are for internal use and may change without notice.
+ */
+package net.openhft.chronicle.testframework.internal.network.proxy;


### PR DESCRIPTION
## Summary
- add package-info for network proxy utilities

## Testing
- `mvn -q verify` *(fails: command not found)*