### PR TITLE
Explain standard accumulators

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -207,3 +207,16 @@ Stream<DynamicTest> demo() {
             });
 }
 ----
+
+== API Metrics Accumulators
+
+The framework includes a small set of predefined accumulator suppliers used by the API metrics analysis. They help to group metric counts in common ways.
+
+* `perMethod()` groups by the full method signature so that overloaded methods are reported separately.
+* `perClassAndMetric()` groups first by class and then by metric, giving a table of metric totals for each class.
+* `PER_METRIC` provides totals for each metric across all classes.
+* `PER_CLASS` totals all metrics for each class without distinction.
+* `PER_PACKAGE` reports a single total for each package.
+* `PER_METHOD_REFERENCE` groups by method name only, ignoring parameter types.
+
+The convenience factories in `Accumulator` expose the first two suppliers for general use. The others are mainly for internal analyses but may be reused when custom behaviour is needed.

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardAccumulators.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardAccumulators.java
@@ -6,18 +6,66 @@ import net.openhft.chronicle.testframework.apimetrics.Accumulator;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+/**
+ * Collection of predefined accumulator suppliers used by the API metrics
+ * subsystem.  Each supplier creates an {@link Accumulator} configured with a
+ * common aggregation scheme.  These constants are intended for quick setup of
+ * standard analysis pipelines and can also serve as examples when creating
+ * bespoke accumulators.
+ */
 public final class StandardAccumulators {
 
-    public static final Supplier<Accumulator> PER_METHOD = () -> Accumulator.of("method", (m, ci, l) -> ((MethodInfo) l).getClassName() + "." + l.getName() + ((MethodInfo) l).getTypeSignatureOrTypeDescriptorStr(), (m, ci, l) -> l instanceof MethodInfo);
-    public static final Supplier<Accumulator> PER_CLASS_AND_METRIC = () -> Accumulator.of(
-            "class",
-            (m, ci, l) -> ci.loadClass().getName(),
-            "metric",
-            (m, ci, l) -> m.toString());
-    static final Supplier<Accumulator> PER_METRIC = () -> Accumulator.of("metric", (m, ci, l) -> m.toString());
-    static final Supplier<Accumulator> PER_CLASS = () -> Accumulator.of("class", (m, ci, l) -> ci.loadClass().getName());
-    static final Supplier<Accumulator> PER_PACKAGE = () -> Accumulator.of("package", (m, ci, l) -> ci.getPackageName());
-    static final Supplier<Accumulator> PER_METHOD_REFERENCE = () -> Accumulator.of("method reference", (m, ci, l) -> ((MethodInfo) l).getClassName() + "::" + l.getName(), (m, ci, l) -> l instanceof MethodInfo);
+    /**
+     * Aggregates results by method signature.  Use this when overloaded
+     * methods should be treated as distinct.
+     */
+    public static final Supplier<Accumulator> PER_METHOD = () -> Accumulator.of(
+            "method",
+            (m, ci, l) -> ((MethodInfo) l).getClassName() + "." + l.getName() +
+                    ((MethodInfo) l).getTypeSignatureOrTypeDescriptorStr(),
+            (m, ci, l) -> l instanceof MethodInfo);
+
+    /**
+     * Aggregates first by class and then by metric.  Useful for a
+     * class-centric view of which metrics apply.
+     */
+    public static final Supplier<Accumulator> PER_CLASS_AND_METRIC = () ->
+            Accumulator.of(
+                    "class",
+                    (m, ci, l) -> ci.loadClass().getName(),
+                    "metric",
+                    (m, ci, l) -> m.toString());
+
+    /**
+     * Aggregates only by metric across the entire scan.  Use this for a
+     * quick overview of metric totals.
+     */
+    static final Supplier<Accumulator> PER_METRIC = () ->
+            Accumulator.of("metric", (m, ci, l) -> m.toString());
+
+    /**
+     * Aggregates results by class.  Helpful when metrics should be summed for
+     * each class irrespective of individual methods.
+     */
+    static final Supplier<Accumulator> PER_CLASS = () ->
+            Accumulator.of("class", (m, ci, l) -> ci.loadClass().getName());
+
+    /**
+     * Aggregates results by package.  Use when a high level overview per
+     * package is required.
+     */
+    static final Supplier<Accumulator> PER_PACKAGE = () ->
+            Accumulator.of("package", (m, ci, l) -> ci.getPackageName());
+
+    /**
+     * Aggregates by class and method name only, ignoring the signature.
+     * Suitable when overloading details are not important.
+     */
+    static final Supplier<Accumulator> PER_METHOD_REFERENCE = () ->
+            Accumulator.of(
+                    "method reference",
+                    (m, ci, l) -> ((MethodInfo) l).getClassName() + "::" + l.getName(),
+                    (m, ci, l) -> l instanceof MethodInfo);
 
     // Suppresses default constructor, ensuring non-instantiability.
     private StandardAccumulators() {


### PR DESCRIPTION
## Summary
- document standard API metrics accumulators
- add Javadoc for predefined accumulator suppliers

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*