### PR TITLE
Document accumulator retrieval

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardApiMetrics.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardApiMetrics.java
@@ -11,6 +11,21 @@ import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Combines the results from a set of accumulators.
+ * <p>
+ * Instances of this class are usually created by
+ * {@link StandardApiMetricsBuilder}. During the build each accumulator is
+ * applied to every selected metric and the results are stored here. Two
+ * collections are kept: one for public packages and another for internal
+ * packages.
+ * <p>
+ * The {@link #accumulators()} method exposes the accumulators used for public
+ * analysis. The {@link #internalAccumulators()} method returns those for
+ * internal analysis. Both methods supply the accumulators in the order they
+ * were added to the builder.
+ */
+
 public final class StandardApiMetrics implements ApiMetrics {
 
     private final Set<Accumulator> accumulators;


### PR DESCRIPTION
## Summary
- describe how StandardApiMetrics collects and exposes accumulators

## Testing
- `mvn -q verify` *(fails: command not found)*