### PR TITLE
Document configuration for API metrics builder

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,6 +66,27 @@ Stream<DynamicTest> demo() {
 }
 ----
 
+== API Metrics Builder
+
+The API metrics feature analyses the public and internal surface of your
+packages. Create the builder via `ApiMetrics.builder()` then supply the
+packages to scan, the metrics to apply and the accumulators that gather the
+results.
+
+[source,java]
+----
+ApiMetrics metrics = ApiMetrics.builder()
+        .addStandardMetrics()
+        .addStandardAccumulators()
+        .addPackage("com.example")
+        .build();
+----
+
+The builder applies no defaults. If you omit metrics or accumulators the
+result will be empty. Packages with `.internal.` in the name, or those ending
+in `.internal`, are collected in a separate internal group.
+
+
 == Combinations
 
 Combinations work like this:

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardApiMetricsBuilder.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardApiMetricsBuilder.java
@@ -10,6 +10,22 @@ import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Standard implementation of {@link ApiMetrics.ApiMetricsBuilder}.
+ * <p>
+ * The builder starts empty. Users specify the packages to scan, any packages
+ * to exclude, the metrics to apply and the accumulators that gather results.
+ * Package exclusions override inclusions.
+ * <p>
+ * Metrics and accumulators can be registered one by one or via
+ * {@link #addStandardMetrics()} and {@link #addStandardAccumulators()}, which
+ * include Chronicle's predefined sets. If no metrics are added {@link #build()}
+ * will throw an {@link IllegalStateException}. Accumulators are optional, but
+ * an empty set yields no output.
+ * <p>
+ * The build step scans the configured packages, respecting exclusions, and
+ * separates results from public and internal packages.
+ */
 public final class StandardApiMetricsBuilder implements ApiMetrics.ApiMetricsBuilder {
 
     // Configurations
@@ -61,6 +77,14 @@ public final class StandardApiMetricsBuilder implements ApiMetrics.ApiMetricsBui
     }
 
     @Override
+    /**
+     * Scans the configured packages and builds the resulting {@link ApiMetrics}.
+     * Packages with names containing {@code .internal.} or ending with
+     * {@code .internal} are treated as internal and are aggregated separately.
+     *
+     * @return the constructed metrics instance
+     * @throws IllegalStateException if no metrics have been supplied
+     */
     public ApiMetrics build() {
         if (metrics.isEmpty())
             throw new IllegalStateException("No Metrics provided");


### PR DESCRIPTION
## Summary
- document how to configure the API metrics builder and its lack of defaults
- describe internal/external package handling in builder javadoc

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*