### PR TITLE
Document thread-safety and logging in CloseableUtil

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/CloseableUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/CloseableUtil.java
@@ -5,8 +5,11 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Utility class to handle closing of {@link java.io.Closeable} or {@link AutoCloseable} resources.
- * This class provides a method to close a resource without throwing any exceptions, logging them instead.
- * Since this class is defined as an enum without instances, it cannot be instantiated and is essentially a utility class.
+ * This class provides a method to close a resource without throwing any exceptions,
+ * logging them instead. The class is stateless and therefore thread-safe. The logging
+ * behaviour is to emit a WARN level message through an {@link org.slf4j.Logger}.
+ * Since this class is defined as an enum without instances, it cannot be instantiated
+ * and is essentially a utility class.
  */
 public enum CloseableUtil {
     ; // This enum has no instances, acting as a utility class
@@ -16,7 +19,8 @@ public enum CloseableUtil {
 
     /**
      * Closes the provided {@link AutoCloseable} resource quietly, without throwing any exceptions.
-     * If an exception does occur while closing the resource, it is logged as a warning and not propagated.
+     * If an exception does occur while closing the resource it is logged at WARN level
+     * and not propagated. The method is thread-safe because it holds no mutable state.
      *
      * @param closeable the closeable resource to close, may be any object implementing {@link AutoCloseable}
      */


### PR DESCRIPTION
## Summary
- document logger behaviour and thread-safety in `CloseableUtil`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*