### PR TITLE
Clarify side effects of port allocation

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/NetworkUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/NetworkUtil.java
@@ -14,17 +14,23 @@ public enum NetworkUtil {
     /**
      * Retrieves an available port number on the local machine.
      * <p>
-     * This method attempts to bind to an automatically allocated port, then returns the port number.
-     * It provides a simple way to find a port that's very likely to be available.
+     * The method opens a {@link ServerSocket} on port {@code 0}, causing the
+     * operating system to allocate an ephemeral port. The socket is closed
+     * straight away, freeing the port. Another process may claim the same port
+     * before the caller can bind to it, so this is best suited to test code.
+     * Firewalls or security managers might also prevent the allocation.
      *
-     * @return a port number that is likely to be available for binding
-     * @throws RuntimeException if an {@link IOException} occurs while trying to create a {@link ServerSocket}
+     * @return a port number that is likely to be available
+     * @throws RuntimeException if an {@link IOException} occurs while creating
+     *                          or closing the socket
      */
     public static int getAvailablePort() {
-        try (final ServerSocket serverSocket = new ServerSocket(0)) { // Attempt to bind to an automatically allocated port
-            return serverSocket.getLocalPort(); // Return the port number
+        // Binds a temporary socket to obtain an ephemeral port.
+        // The port is released when the socket closes.
+        try (final ServerSocket serverSocket = new ServerSocket(0)) {
+            return serverSocket.getLocalPort();
         } catch (IOException e) {
-            throw new RuntimeException("Failed to find an available port", e); // Propagate the exception as a runtime exception
+            throw new RuntimeException("Failed to find an available port", e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- document side effects of obtaining an available port

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*