### PR TITLE
Improve executor shutdown docs

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/ExecutorServiceUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/ExecutorServiceUtil.java
@@ -4,10 +4,18 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Utility class providing methods to shut down an {@link ExecutorService}
- * and wait for its termination, with or without forcibly interrupting running tasks.
+ * Utility class providing helper methods to stop an {@link ExecutorService}
+ * and wait for its termination. Two shutdown styles are offered: graceful via
+ * {@link ExecutorService#shutdown()} and forcible via
+ * {@link ExecutorService#shutdownNow()}.
  * <p>
- * This is an enum with no instances, serving solely for namespace control.
+ * In both cases the caller waits using
+ * {@link ExecutorService#awaitTermination(long, TimeUnit)}. If the executor does
+ * not terminate within the allotted time or the waiting thread is interrupted an
+ * {@link IllegalStateException} is thrown. Interrupt status is restored before
+ * the exception is propagated.
+ * <p>
+ * This enum has no instances and exists solely as a namespace.
  */
 public enum ExecutorServiceUtil {
     ;
@@ -15,12 +23,20 @@ public enum ExecutorServiceUtil {
     private static final int DEFAULT_TIME_TO_WAIT_SECONDS = 5;
 
     /**
-     * Shut down an executor service and wait for it to terminate within the given timeout.
+     * Initiates a graceful shutdown and waits for termination.
+     * <p>
+     * Calls {@link ExecutorService#shutdown()} so no new tasks are accepted. Any
+     * tasks already running are left to finish. The calling thread then waits for
+     * at most {@code timeout} in the supplied {@code unit}. If the executor still
+     * has threads alive when the wait expires, or if the waiting thread is
+     * interrupted, an {@link IllegalStateException} is thrown and the interrupt
+     * status is preserved.
      *
-     * @param executorService The executor service
-     * @param timeout         The maximum time to wait
-     * @param unit            The unit of the timeout argument
-     * @throws IllegalStateException If the executor service didn't terminate within the timeout
+     * @param executorService the executor to shut down
+     * @param timeout         maximum time to wait
+     * @param unit            unit of the timeout argument
+     * @throws IllegalStateException if the executor did not terminate in time or
+     *                               the waiting thread was interrupted
      */
     public static void shutdownAndWaitForTermination(ExecutorService executorService, long timeout, TimeUnit unit) {
         executorService.shutdown();
@@ -28,10 +44,11 @@ public enum ExecutorServiceUtil {
     }
 
     /**
-     * Shut down an executor service and wait 5 seconds for it to terminate.
+     * Variant of {@link #shutdownAndWaitForTermination(ExecutorService, long, TimeUnit)}
+     * that waits for a default of five seconds.
      *
-     * @param executorService The executor service
-     * @throws IllegalStateException If it didn't terminate within the default time of 5 seconds
+     * @param executorService the executor to shut down
+     * @throws IllegalStateException if it does not terminate within five seconds
      */
     public static void shutdownAndWaitForTermination(ExecutorService executorService) {
         executorService.shutdown();
@@ -39,29 +56,41 @@ public enum ExecutorServiceUtil {
     }
 
     /**
-     * Shut down an executor service, interrupting all threads, and wait 5 seconds for it to terminate.
+     * Forces shutdown by interrupting all threads and waits a default of five seconds
+     * for the executor to finish.
      *
-     * @param executorService The executor service
-     * @throws IllegalStateException If it didn't terminate within the default time of 5 seconds
+     * @param executorService the executor to stop
+     * @throws IllegalStateException if it does not terminate within five seconds
      */
     public static void shutdownForciblyAndWaitForTermination(ExecutorService executorService) {
         shutdownForciblyAndWaitForTermination(executorService, DEFAULT_TIME_TO_WAIT_SECONDS, TimeUnit.SECONDS);
     }
 
     /**
-     * Shut down an executor service, interrupting all threads, and wait for it to terminate within the given timeout.
+     * Attempts to stop all active tasks and waits for termination.
+     * <p>
+     * Invokes {@link ExecutorService#shutdownNow()} to interrupt running tasks and
+     * to discard queued tasks. The calling thread then waits for up to
+     * {@code timeout} in the given {@code unit}. Should the executor fail to finish
+     * within that window, or if the waiting thread is interrupted, an
+     * {@link IllegalStateException} is thrown and the interrupt status is preserved.
      *
-     * @param executorService The executor service
-     * @param timeout         The maximum time to wait
-     * @param unit            The unit of the timeout argument
-     * @throws IllegalStateException If it didn't terminate within the specified timeout
+     * @param executorService the executor to stop
+     * @param timeout         maximum time to wait
+     * @param unit            unit of the timeout argument
+     * @throws IllegalStateException if termination does not occur in time or if the wait is interrupted
      */
     public static void shutdownForciblyAndWaitForTermination(ExecutorService executorService, long timeout, TimeUnit unit) {
         executorService.shutdownNow(); // Interrupt all running tasks
         waitForTermination(executorService, timeout, unit);
     }
 
-    // Waits for the ExecutorService to terminate within the specified time
+    /**
+     * Blocks until the executor terminates or the timeout elapses.
+     * If the wait times out or the thread is interrupted an
+     * {@link IllegalStateException} is thrown. Interrupt status is restored
+     * before throwing.
+     */
     private static void waitForTermination(ExecutorService executorService, long timeToWait, TimeUnit units) {
         try {
             if (!executorService.awaitTermination(timeToWait, units)) {


### PR DESCRIPTION
## Summary
- clarify that shutdown is graceful or forcible and describe waiting logic
- document default timeout helpers
- detail interrupt handling while waiting for termination

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*