### PR TITLE
Clarify Metric weight documentation

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/apimetrics/Metric.java
+++ b/src/main/java/net/openhft/chronicle/testframework/apimetrics/Metric.java
@@ -7,10 +7,24 @@ import java.util.function.Predicate;
 /**
  * A Metric defines a rule used when scoring an API element. Typical metrics
  * check for public or protected classes, methods that can be overridden and
- * public fields. Each metric carries a weight showing its relative importance.
- * For instance a public class may have weight 10 while a protected method may
- * weigh 1. Accumulators sum the weights of all applicable metrics to produce an
+ * public fields. Each metric carries a weight indicating how much it
+ * contributes to the final score. Higher weights have greater influence. For
+ * instance a public class may have weight 10 while a protected method may weigh
+ * 1. Accumulators sum the weights of all applicable metrics to produce an
  * overall score.
+ *
+ * <p>Example usage:</p>
+ *
+ * <pre>{@code
+ * Metric<Class<?>> hasPublicConstructor = Metric.of(
+ *         Class.class,
+ *         c -> c.getConstructors().length > 0,
+ *         "hasPublicConstructor",
+ *         5);
+ * }</pre>
+ *
+ * <p>This metric adds five points whenever a class exposes a public
+ * constructor.</p>
  *
  * @param <T> the type of element to which this metric can be applied.
  */
@@ -24,18 +38,20 @@ public interface Metric<T> {
     Class<T> nodeType();
 
     /**
-     * Checks whether the metric is applicable to the given node.
+     * Checks whether the metric applies to the supplied node.
      *
-     * @param node The node to check.
-     * @return True if the metric is applicable, false otherwise.
+     * @param node the element being evaluated
+     * @return {@code true} if the metric should be counted; {@code false}
+     *         otherwise
      */
     boolean isApplicable(T node);
 
     /**
-     * Gets the weight of the metric. The weight represents the importance or
-     * the value of the metric and can be used to calculate a cumulative score.
+     * Gets the weight of the metric. The weight is the amount added to the
+     * cumulative score whenever {@link #isApplicable(Object)} returns
+     * {@code true}.
      *
-     * @return The weight of the metric.
+     * @return the weight of the metric
      */
     double weight();
 
@@ -43,10 +59,10 @@ public interface Metric<T> {
      * Factory method to create a new instance of a Metric with the given parameters.
      *
      * @param <T>      The type of element to which this metric can be applied.
-     * @param nodeType The class type of the element.
-     * @param filter   The predicate to determine if the metric is applicable.
-     * @param name     The name of the metric.
-     * @param weight   The weight of the metric.
+     * @param nodeType class the metric operates on
+     * @param filter   predicate used by {@link #isApplicable(Object)}
+     * @param name     human readable name for reporting
+     * @param weight   value added to the score when applicable
      * @return A new Metric instance.
      */
     static <T> Metric<T> of(final Class<T> nodeType,


### PR DESCRIPTION
## Summary
- expand Metric class Javadoc with a usage example
- clarify the definition of weight and how it influences scores
- document parameters for `isApplicable` and factory method

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*