### PR TITLE
Update apimetrics package-info

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/apimetrics/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/apimetrics/package-info.java
@@ -13,9 +13,11 @@
  * instance with the builder. That instance can be applied to the chosen
  * packages.
  *
- * <p>Example usage might include analyzing code for compliance with specific
- * coding standards, detecting patterns, or generating reports for code quality
- * assurance.
+ * <p>Example usage might include creating customised {@link Metric} instances and
+ * a tailored {@link Accumulator}, followed by the builder workflow to analyse
+ * packages for compliance with specific coding standards, detecting patterns, or
+ * generating reports for code quality assurance. Typical use cases include
+ * maintaining API consistency across releases.
  *
  * @see net.openhft.chronicle.testframework.apimetrics.ApiMetrics
  * @see net.openhft.chronicle.testframework.apimetrics.Accumulator


### PR DESCRIPTION
## Summary
- expand the example usage in `package-info.java`
- mention customised Metric instances, tailored Accumulator and builder workflow
- add reference to maintaining API consistency

## Testing
- `mvn -q verify` *(fails: mvn not found)*