### PR TITLE
Skip URI which point inside a JAR

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/CodeStructureVerifier.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/CodeStructureVerifier.java
@@ -167,8 +167,13 @@ public class CodeStructureVerifier {
 
         private void skipClasses() {
             importOptions.add(location -> {
-                String className = parseClassName(location.asURI());
-                return !classesToExclude.contains(className);
+                try {
+                    String className = parseClassName(location.asURI());
+                    return !classesToExclude.contains(className);
+                } catch (RuntimeException e) {
+                    log.debug("Failed to parse class name from location: {}", location, e);
+                    return false;
+                }
             });
         }
 


### PR DESCRIPTION
When the test framework scans classes (e.g., inside JARs), failures in `parseClassName(location.asURI())` currently bubble up as long, low-signal stack traces. This PR wraps the parse step with targeted logging so developers can immediately see *which location* caused the failure, turning “mystery exceptions” into actionable diagnostics.

## Why

* The current behaviour emits long, unhelpful exceptions when a file/resource inside a JAR has an unexpected URI shape or malformed entry.
* Developers need to know *exactly which JAR entry or path* triggered the failure to fix build/test issues quickly.
* The new message provides that context without overwhelming error output.
