### PR TITLE
Refine JUnit 5 migration fixes and test cleanup

### DIFF
--- a/src/main/java/net/openhft/chronicle/testframework/Series.java
+++ b/src/main/java/net/openhft/chronicle/testframework/Series.java
@@ -64,5 +64,4 @@ public final class Series {
     public static LongStream primes() {
         return SeriesUtil.primes(); // Delegating to internal utility
     }
-
 }

--- a/src/main/java/net/openhft/chronicle/testframework/internal/DelegationBuilder.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/DelegationBuilder.java
@@ -81,5 +81,4 @@ public final class DelegationBuilder<T, D> implements Delegation.Builder<T, D> {
                     return method.invoke(delegate, args);
                 });
     }
-
 }

--- a/src/main/java/net/openhft/chronicle/testframework/internal/SeriesUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/SeriesUtil.java
@@ -51,5 +51,4 @@ public final class SeriesUtil {
         return LongStream.rangeClosed(2, (int) (Math.sqrt(number)))
                 .allMatch(n -> number % n != 0);
     }
-
 }

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/ApiMetricsUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/ApiMetricsUtil.java
@@ -13,5 +13,4 @@ final class ApiMetricsUtil {
     // Suppresses default constructor, ensuring non-instantiability.
     private ApiMetricsUtil() {
     }
-
 }

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardMetrics.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardMetrics.java
@@ -95,5 +95,4 @@ final class StandardMetrics {
             }
         };
     }
-
 }

--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/CodeStructureVerifier.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/CodeStructureVerifier.java
@@ -223,5 +223,4 @@ public class CodeStructureVerifier {
         }
 
     }
-
 }

--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/DtoAliasMustInvokeBootstrapRuleSupplier.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/DtoAliasMustInvokeBootstrapRuleSupplier.java
@@ -83,5 +83,4 @@ public class DtoAliasMustInvokeBootstrapRuleSupplier implements Supplier<ArchRul
             return totalCount;
         }
     }
-
 }

--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/NonInternalClassesMustNotExtendInternalClassesRuleSupplier.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/NonInternalClassesMustNotExtendInternalClassesRuleSupplier.java
@@ -41,5 +41,4 @@ public class NonInternalClassesMustNotExtendInternalClassesRuleSupplier implemen
                     }
                 }).allowEmptyShould(true);
     }
-
 }

--- a/src/main/java/net/openhft/chronicle/testframework/internal/dto/StandardDtoTester.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/dto/StandardDtoTester.java
@@ -191,5 +191,4 @@ final class StandardDtoTester<T> implements DtoTester {
     private <E> List<E> newList() {
         return new ArrayList<>();
     }
-
 }

--- a/src/main/java/net/openhft/chronicle/testframework/internal/function/VanillaThrowingConsumer.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/function/VanillaThrowingConsumer.java
@@ -36,5 +36,4 @@ public final class VanillaThrowingConsumer<T> implements Consumer<T> {
             throw new ThrowingConsumerException(e);
         }
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/testframework/ApiMetricsTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/ApiMetricsTest.java
@@ -7,7 +7,7 @@ import net.openhft.chronicle.testframework.apimetrics.Accumulator;
 import net.openhft.chronicle.testframework.apimetrics.ApiMetrics;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ApiMetricsTest {
 

--- a/src/test/java/net/openhft/chronicle/testframework/SeriesTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/SeriesTest.java
@@ -48,5 +48,4 @@ class SeriesTest {
                 .toArray();
         assertArrayEquals(expected, actual);
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/testframework/SeriesTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/SeriesTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.function.Supplier;
 import java.util.stream.LongStream;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class SeriesTest {
 

--- a/src/test/java/net/openhft/chronicle/testframework/WaitersTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/WaitersTest.java
@@ -7,8 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class WaitersTest {
 

--- a/src/test/java/net/openhft/chronicle/testframework/codestructure/CodeStructureVerifierTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/codestructure/CodeStructureVerifierTest.java
@@ -8,7 +8,7 @@ import net.openhft.chronicle.testframework.internal.codestructure.rules.DtoAlias
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class CodeStructureVerifierTest {
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/CombPermDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/CombPermDemoTest.java
@@ -7,7 +7,7 @@ import net.openhft.chronicle.testframework.Combination;
 import net.openhft.chronicle.testframework.Permutation;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class CombPermDemoTest {
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/CombinationDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/CombinationDemoTest.java
@@ -28,8 +28,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Per Minborg

--- a/src/test/java/net/openhft/chronicle/testframework/internal/CombinationDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/CombinationDemoTest.java
@@ -73,5 +73,4 @@ final class CombinationDemoTest {
             return true;
         }
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/testframework/internal/CombinationTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/CombinationTest.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
 import static java.util.Arrays.asList;
 import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Per Minborg

--- a/src/test/java/net/openhft/chronicle/testframework/internal/DelegationBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/DelegationBuilderTest.java
@@ -3,7 +3,6 @@
  */
 package net.openhft.chronicle.testframework.internal;
 
-import net.openhft.chronicle.testframework.Delegation;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;

--- a/src/test/java/net/openhft/chronicle/testframework/internal/ListDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/ListDemoTest.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ListDemoTest {
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/ListDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/ListDemoTest.java
@@ -147,5 +147,4 @@ public class ListDemoTest {
         final Iterator<T> iterator = set.iterator();
         return new Tuple<>(iterator.next(), iterator.next());
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/testframework/internal/PermutationDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/PermutationDemoTest.java
@@ -129,5 +129,4 @@ final class PermutationDemoTest {
                     '}';
         }
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/testframework/internal/PermutationDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/PermutationDemoTest.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 final class PermutationDemoTest {
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/PermutationTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/PermutationTest.java
@@ -30,20 +30,19 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 final class PermutationTest {
 
     @TestFactory
     Stream<DynamicTest> factorial() {
         return IntStream.range(0, 10)
-            .mapToObj(i ->
-                DynamicTest.dynamicTest("factorial(" + i + ")",
-                    () -> {
-                        assertEquals(Permutation.factorial(i), fac(i));
-                    })
-            );
+                .mapToObj(i ->
+                        DynamicTest.dynamicTest("factorial(" + i + ")",
+                                () -> {
+                                    assertEquals(Permutation.factorial(i), fac(i));
+                                })
+                );
     }
 
     @Test
@@ -60,7 +59,7 @@ final class PermutationTest {
         });
     }
 
-    private static final List<Integer> LIST = Arrays.asList(1,2,3);
+    private static final List<Integer> LIST = Arrays.asList(1, 2, 3);
 
     /*
         1, 2, 3
@@ -105,8 +104,8 @@ final class PermutationTest {
     void of() {
         final List<List<Integer>> expected = expectedFor123();
         final List<List<Integer>> actual =
-            Permutation.of(1,2,3)
-            .collect(toList());
+                Permutation.of(1, 2, 3)
+                        .collect(toList());
 
         assertEquals(expected, actual);
     }
@@ -116,7 +115,7 @@ final class PermutationTest {
         final List<List<Integer>> expected = expectedFor123();
         final List<List<Integer>> actual =
                 Permutation.of(Stream.of(1, 2, 3))
-            .collect(toList());
+                        .collect(toList());
 
         assertEquals(expected, actual);
     }
@@ -125,20 +124,20 @@ final class PermutationTest {
     void ofList() {
         final List<List<Integer>> expected = expectedFor123();
         final List<List<Integer>> actual =
-            Permutation.of(LIST)
-                .collect(toList());
+                Permutation.of(LIST)
+                        .collect(toList());
 
         assertEquals(expected, actual);
     }
 
     private List<List<Integer>> expectedFor123() {
         return Stream.of(
-            Arrays.asList(1,2,3),
-            Arrays.asList(1,3,2),
-            Arrays.asList(2,1,3),
-            Arrays.asList(2,3,1),
-            Arrays.asList(3,1,2),
-            Arrays.asList(3,2,1)
+                Arrays.asList(1, 2, 3),
+                Arrays.asList(1, 3, 2),
+                Arrays.asList(2, 1, 3),
+                Arrays.asList(2, 3, 1),
+                Arrays.asList(3, 1, 2),
+                Arrays.asList(3, 2, 1)
         ).collect(toList());
     }
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/PermutationTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/PermutationTest.java
@@ -145,5 +145,4 @@ final class PermutationTest {
         if (i == 0) return 1;
         return i * fac(i - 1);
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/testframework/internal/ProductDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/ProductDemoTest.java
@@ -28,8 +28,7 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 final class ProductDemoTest {
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/ProductDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/ProductDemoTest.java
@@ -60,5 +60,4 @@ final class ProductDemoTest {
                 tuple -> tuple.second().accept(tuple.first())
         );
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/testframework/internal/ProductTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/ProductTest.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 final class ProductTest {
 
@@ -47,6 +47,7 @@ final class ProductTest {
         }
         assertEquals(expected, actual);
     }
+
     @Test
     void product2Stream() {
         final List<String> strings = Arrays.asList("A", "B", "C");
@@ -76,7 +77,7 @@ final class ProductTest {
         final List<Product.Product3<String, Integer, Long>> expected = new ArrayList<>();
         for (String s : strings) {
             for (Integer i : integers) {
-                for (Long l:longs) {
+                for (Long l : longs) {
                     expected.add(new ProductUtil.Product3Impl<>(s, i, l));
                 }
             }
@@ -96,7 +97,7 @@ final class ProductTest {
         final List<Product.Product3<String, Integer, Long>> expected = new ArrayList<>();
         for (String s : strings) {
             for (Integer i : integers) {
-                for (Long l:longs) {
+                for (Long l : longs) {
                     expected.add(new ProductUtil.Product3Impl<>(s, i, l));
                 }
             }

--- a/src/test/java/net/openhft/chronicle/testframework/internal/ProductTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/ProductTest.java
@@ -104,5 +104,4 @@ final class ProductTest {
         }
         assertEquals(expected, actual);
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/testframework/internal/SeriesDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/SeriesDemoTest.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.function.Supplier;
 import java.util.stream.LongStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class SeriesDemoTest {
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/VanillaFlakyTestRunnerTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/VanillaFlakyTestRunnerTest.java
@@ -115,5 +115,4 @@ class VanillaFlakyTestRunnerTest {
             throw new IllegalStateException("" + countDown--);
         }
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/testframework/internal/VanillaNamedConsumerTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/VanillaNamedConsumerTest.java
@@ -36,5 +36,4 @@ class VanillaNamedConsumerTest {
     void nullInConstructorName() {
         assertThrows(NullPointerException.class, () -> new VanillaNamedConsumer<>(v -> {}, null));
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/testframework/internal/VanillaThrowingConsumerTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/VanillaThrowingConsumerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class VanillaThrowingConsumerTest {
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/apimetrics/Foo.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/apimetrics/Foo.java
@@ -21,5 +21,4 @@ class Foo {
     protected int zero() {
         return 0;
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardApiMetricsBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardApiMetricsBuilderTest.java
@@ -23,5 +23,4 @@ final class StandardApiMetricsBuilderTest {
                 .forEach(System.out::println);
 
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/testframework/internal/network/proxy/TcpProxyTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/network/proxy/TcpProxyTest.java
@@ -23,7 +23,7 @@ import static net.openhft.chronicle.testframework.ExecutorServiceUtil.shutdownAn
 import static net.openhft.chronicle.testframework.NetworkUtil.getAvailablePort;
 import static net.openhft.chronicle.testframework.ThreadUtil.pause;
 import static net.openhft.chronicle.testframework.Waiters.waitForCondition;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DisabledOnOs(value = OS.MAC, disabledReason = "MacOS loopback strangeness causes intermittent failures")
 class TcpProxyTest {

--- a/src/test/java/net/openhft/chronicle/testframework/internal/network/proxy/TcpProxyTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/network/proxy/TcpProxyTest.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static net.openhft.chronicle.testframework.ExecutorServiceUtil.shutdownAndWaitForTermination;
-import static net.openhft.chronicle.testframework.NetworkUtil.getAvailablePort;
 import static net.openhft.chronicle.testframework.ThreadUtil.pause;
 import static net.openhft.chronicle.testframework.Waiters.waitForCondition;
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/net/openhft/chronicle/testframework/mappedfiles/MappedFileUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/mappedfiles/MappedFileUtilTest.java
@@ -19,8 +19,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.regex.Matcher;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class MappedFileUtilTest {
 

--- a/src/test/java/net/openhft/chronicle/testframework/process/JavaProcessBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/process/JavaProcessBuilderTest.java
@@ -6,8 +6,7 @@ package net.openhft.chronicle.testframework.process;
 import org.junit.jupiter.api.Test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class JavaProcessBuilderTest {
 


### PR DESCRIPTION
## Summary
- carry the `feature/junit5` branch changes against `develop`
- include the recent JUnit 5 migration fixes and test cleanup already pushed from the workspace
- keep this repo aligned with the broader migration rollout

## Testing
- not run as part of this PR creation step
