### PR TITLE
docs: bump copyright year end to 2026

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,10 @@
     <description>Chronicle-Test-Framework</description>
     <packaging>jar</packaging>
 
+    <properties>
+        <license.year>2013-2026</license.year>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/src/main/java/net/openhft/chronicle/testframework/CloseableUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/CloseableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/main/java/net/openhft/chronicle/testframework/Combination.java
+++ b/src/main/java/net/openhft/chronicle/testframework/Combination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  *

--- a/src/main/java/net/openhft/chronicle/testframework/Delegation.java
+++ b/src/main/java/net/openhft/chronicle/testframework/Delegation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/main/java/net/openhft/chronicle/testframework/ExecutorServiceUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/ExecutorServiceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/main/java/net/openhft/chronicle/testframework/FlakyTestRunner.java
+++ b/src/main/java/net/openhft/chronicle/testframework/FlakyTestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/main/java/net/openhft/chronicle/testframework/GcControls.java
+++ b/src/main/java/net/openhft/chronicle/testframework/GcControls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/main/java/net/openhft/chronicle/testframework/NetworkUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/NetworkUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/main/java/net/openhft/chronicle/testframework/Permutation.java
+++ b/src/main/java/net/openhft/chronicle/testframework/Permutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  *

--- a/src/main/java/net/openhft/chronicle/testframework/Product.java
+++ b/src/main/java/net/openhft/chronicle/testframework/Product.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/main/java/net/openhft/chronicle/testframework/Series.java
+++ b/src/main/java/net/openhft/chronicle/testframework/Series.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/main/java/net/openhft/chronicle/testframework/ThreadUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/ThreadUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/main/java/net/openhft/chronicle/testframework/Waiters.java
+++ b/src/main/java/net/openhft/chronicle/testframework/Waiters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/main/java/net/openhft/chronicle/testframework/apimetrics/Accumulator.java
+++ b/src/main/java/net/openhft/chronicle/testframework/apimetrics/Accumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.apimetrics;
 

--- a/src/main/java/net/openhft/chronicle/testframework/apimetrics/ApiMetrics.java
+++ b/src/main/java/net/openhft/chronicle/testframework/apimetrics/ApiMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.apimetrics;
 

--- a/src/main/java/net/openhft/chronicle/testframework/apimetrics/Metric.java
+++ b/src/main/java/net/openhft/chronicle/testframework/apimetrics/Metric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.apimetrics;
 

--- a/src/main/java/net/openhft/chronicle/testframework/apimetrics/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/apimetrics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Provides the classes and interfaces necessary for API metrics analysis within

--- a/src/main/java/net/openhft/chronicle/testframework/dto/DtoTester.java
+++ b/src/main/java/net/openhft/chronicle/testframework/dto/DtoTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.dto;
 

--- a/src/main/java/net/openhft/chronicle/testframework/dto/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/dto/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Provides interfaces and classes for testing Data Transfer Objects (DTOs) within

--- a/src/main/java/net/openhft/chronicle/testframework/exception/ExceptionTracker.java
+++ b/src/main/java/net/openhft/chronicle/testframework/exception/ExceptionTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.exception;
 

--- a/src/main/java/net/openhft/chronicle/testframework/exception/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/exception/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Provides classes and interfaces for tracking and asserting exceptions during testing.

--- a/src/main/java/net/openhft/chronicle/testframework/function/HasName.java
+++ b/src/main/java/net/openhft/chronicle/testframework/function/HasName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.function;
 

--- a/src/main/java/net/openhft/chronicle/testframework/function/NamedConsumer.java
+++ b/src/main/java/net/openhft/chronicle/testframework/function/NamedConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.function;
 

--- a/src/main/java/net/openhft/chronicle/testframework/function/ThrowingConsumer.java
+++ b/src/main/java/net/openhft/chronicle/testframework/function/ThrowingConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.function;
 

--- a/src/main/java/net/openhft/chronicle/testframework/function/ThrowingConsumerException.java
+++ b/src/main/java/net/openhft/chronicle/testframework/function/ThrowingConsumerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.function;
 

--- a/src/main/java/net/openhft/chronicle/testframework/function/TriConsumer.java
+++ b/src/main/java/net/openhft/chronicle/testframework/function/TriConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.function;
 

--- a/src/main/java/net/openhft/chronicle/testframework/function/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/function/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package provides a set of functional interfaces and related utility classes to enhance

--- a/src/main/java/net/openhft/chronicle/testframework/internal/CombinationUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/CombinationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  *

--- a/src/main/java/net/openhft/chronicle/testframework/internal/DelegationBuilder.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/DelegationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/PermutationUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/PermutationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  *

--- a/src/main/java/net/openhft/chronicle/testframework/internal/ProductUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/ProductUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/SeriesUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/SeriesUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/VanillaExceptionTracker.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/VanillaExceptionTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/VanillaFlakyTestRunner.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/VanillaFlakyTestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/VanillaFlakyTestRunnerBuilder.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/VanillaFlakyTestRunnerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/ApiMetricsUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/ApiMetricsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.apimetrics;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardAccumulator1.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardAccumulator1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.apimetrics;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardAccumulator2.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardAccumulator2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.apimetrics;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardAccumulators.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardAccumulators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.apimetrics;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardApiMetrics.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardApiMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.apimetrics;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardApiMetricsBuilder.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardApiMetricsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.apimetrics;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardMetric.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.apimetrics;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardMetrics.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.apimetrics;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/apimetrics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Internal implementations supporting {@link net.openhft.chronicle.testframework.apimetrics}.

--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/CodeStructureVerifier.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/CodeStructureVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.codestructure;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Contains components that set up and run ArchUnit based code structure tests.

--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/DtoAliasMustInvokeBootstrapRuleSupplier.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/DtoAliasMustInvokeBootstrapRuleSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.codestructure.rules;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/MainMethodRuleSupplier.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/MainMethodRuleSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.codestructure.rules;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/NonInternalClassesMustNotExtendInternalClassesRuleSupplier.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/NonInternalClassesMustNotExtendInternalClassesRuleSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.codestructure.rules;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/RuleUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/RuleUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.codestructure.rules;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/codestructure/rules/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Provides the default ArchUnit rule suppliers used by

--- a/src/main/java/net/openhft/chronicle/testframework/internal/dto/DtoTesterBuilder.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/dto/DtoTesterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.dto;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/dto/StandardDtoTester.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/dto/StandardDtoTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.dto;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/dto/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/dto/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Contains internal builder and tester implementations used to verify DTO behaviour.

--- a/src/main/java/net/openhft/chronicle/testframework/internal/function/VanillaNamedConsumer.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/function/VanillaNamedConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.function;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/function/VanillaThrowingConsumer.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/function/VanillaThrowingConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.function;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/function/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/function/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Provides internal implementations backing the public {@code function} package.

--- a/src/main/java/net/openhft/chronicle/testframework/internal/network/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/network/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Contains network utilities used internally by the test framework.

--- a/src/main/java/net/openhft/chronicle/testframework/internal/network/proxy/ProxyConnection.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/network/proxy/ProxyConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.network.proxy;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/network/proxy/TcpProxy.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/network/proxy/TcpProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.network.proxy;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/network/proxy/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/network/proxy/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Provides a lightweight TCP proxy for tests.

--- a/src/main/java/net/openhft/chronicle/testframework/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/main/java/net/openhft/chronicle/testframework/internal/process/InternalJavaProcessBuilder.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/process/InternalJavaProcessBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.process;
 

--- a/src/main/java/net/openhft/chronicle/testframework/internal/process/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/process/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Contains helpers used to spawn Java processes when tests require them.

--- a/src/main/java/net/openhft/chronicle/testframework/mappedfiles/MappedFileUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/mappedfiles/MappedFileUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.mappedfiles;
 

--- a/src/main/java/net/openhft/chronicle/testframework/mappedfiles/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/mappedfiles/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Provides utility classes for working with mapped files, specifically targeting

--- a/src/main/java/net/openhft/chronicle/testframework/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * The {@code net.openhft.chronicle.testframework} package provides a collection of utility classes and enums

--- a/src/main/java/net/openhft/chronicle/testframework/process/JavaProcessBuilder.java
+++ b/src/main/java/net/openhft/chronicle/testframework/process/JavaProcessBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.process;
 

--- a/src/main/java/net/openhft/chronicle/testframework/process/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/process/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * The {@code net.openhft.chronicle.testframework.internal.process} package provides internal implementations

--- a/src/main/java11/module-info.java.txt
+++ b/src/main/java11/module-info.java.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  * https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/core/Bootstrap.java
+++ b/src/test/java/net/openhft/chronicle/core/Bootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.core;
 

--- a/src/test/java/net/openhft/chronicle/testframework/ApiMetricsTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/ApiMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/test/java/net/openhft/chronicle/testframework/SeriesTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/SeriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/test/java/net/openhft/chronicle/testframework/WaitersTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/WaitersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework;
 

--- a/src/test/java/net/openhft/chronicle/testframework/codestructure/Bootstrap.java
+++ b/src/test/java/net/openhft/chronicle/testframework/codestructure/Bootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.codestructure;
 

--- a/src/test/java/net/openhft/chronicle/testframework/codestructure/CodeStructureVerifierTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/codestructure/CodeStructureVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.codestructure;
 

--- a/src/test/java/net/openhft/chronicle/testframework/codestructure/CompliantMain.java
+++ b/src/test/java/net/openhft/chronicle/testframework/codestructure/CompliantMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.codestructure;
 

--- a/src/test/java/net/openhft/chronicle/testframework/codestructure/DelegatesToInternal.java
+++ b/src/test/java/net/openhft/chronicle/testframework/codestructure/DelegatesToInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.codestructure;
 

--- a/src/test/java/net/openhft/chronicle/testframework/codestructure/DtoAlias.java
+++ b/src/test/java/net/openhft/chronicle/testframework/codestructure/DtoAlias.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.codestructure;
 

--- a/src/test/java/net/openhft/chronicle/testframework/codestructure/ExtendsInternal.java
+++ b/src/test/java/net/openhft/chronicle/testframework/codestructure/ExtendsInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.codestructure;
 

--- a/src/test/java/net/openhft/chronicle/testframework/codestructure/NonCompliantMainNoStaticBlock.java
+++ b/src/test/java/net/openhft/chronicle/testframework/codestructure/NonCompliantMainNoStaticBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.codestructure;
 

--- a/src/test/java/net/openhft/chronicle/testframework/codestructure/broken/DtoAlias.java
+++ b/src/test/java/net/openhft/chronicle/testframework/codestructure/broken/DtoAlias.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.codestructure.broken;
 

--- a/src/test/java/net/openhft/chronicle/testframework/codestructure/internal/ExampleInternal.java
+++ b/src/test/java/net/openhft/chronicle/testframework/codestructure/internal/ExampleInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.codestructure.internal;
 

--- a/src/test/java/net/openhft/chronicle/testframework/codestructure/package-info.java
+++ b/src/test/java/net/openhft/chronicle/testframework/codestructure/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package contains classes that are used to test the code structure of various other code base elements.

--- a/src/test/java/net/openhft/chronicle/testframework/dto/DtoTesterDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/dto/DtoTesterDemoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.dto;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/CombPermDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/CombPermDemoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/CombinationDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/CombinationDemoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  *

--- a/src/test/java/net/openhft/chronicle/testframework/internal/CombinationTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/CombinationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  *

--- a/src/test/java/net/openhft/chronicle/testframework/internal/DelegationBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/DelegationBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/ListDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/ListDemoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/PermutationDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/PermutationDemoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  *

--- a/src/test/java/net/openhft/chronicle/testframework/internal/PermutationTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/PermutationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  *

--- a/src/test/java/net/openhft/chronicle/testframework/internal/ProductDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/ProductDemoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  *

--- a/src/test/java/net/openhft/chronicle/testframework/internal/ProductTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/ProductTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  *

--- a/src/test/java/net/openhft/chronicle/testframework/internal/SeriesDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/SeriesDemoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/VanillaExceptionTrackerTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/VanillaExceptionTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/VanillaFlakyTestRunnerTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/VanillaFlakyTestRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/VanillaNamedConsumerTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/VanillaNamedConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/VanillaThrowingConsumerTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/VanillaThrowingConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/apimetrics/Foo.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/apimetrics/Foo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.apimetrics;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/apimetrics/MyEnum.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/apimetrics/MyEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.apimetrics;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardApiMetricsBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardApiMetricsBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.apimetrics;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardMetricsTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/apimetrics/StandardMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.apimetrics;
 

--- a/src/test/java/net/openhft/chronicle/testframework/internal/network/proxy/TcpProxyTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/network/proxy/TcpProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.internal.network.proxy;
 

--- a/src/test/java/net/openhft/chronicle/testframework/mappedfiles/MappedFileUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/mappedfiles/MappedFileUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.mappedfiles;
 

--- a/src/test/java/net/openhft/chronicle/testframework/process/BadMain.java
+++ b/src/test/java/net/openhft/chronicle/testframework/process/BadMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.process;
 

--- a/src/test/java/net/openhft/chronicle/testframework/process/GoodMain.java
+++ b/src/test/java/net/openhft/chronicle/testframework/process/GoodMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.process;
 

--- a/src/test/java/net/openhft/chronicle/testframework/process/JavaProcessBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/process/JavaProcessBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.testframework.process;
 


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, etc.) are intentionally left alone.
- Adds a local `license.year=2013-2026` override in the project POM so `license-maven-plugin` validates the updated headers correctly on CI.
- Behaviour-neutral; no logic changes.

## Test plan
- [ ] Visual diff review - expect header year updates plus the `license.year` POM override.
- [ ] `mvn -DskipTests license:check`
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)