### PR TITLE
docs: upgrade http:// to https:// in docs and comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/net/openhft/chronicle/testframework/Combination.java
+++ b/src/main/java/net/openhft/chronicle/testframework/Combination.java
@@ -9,7 +9,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/src/main/java/net/openhft/chronicle/testframework/Permutation.java
+++ b/src/main/java/net/openhft/chronicle/testframework/Permutation.java
@@ -9,7 +9,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
  * sizes. Consider sampling when dealing with larger collections.
  * <p>
  * General permutation support from
- * http://minborgsjavapot.blogspot.com/2015/07/java-8-master-permutations.html
+ * https://minborgsjavapot.blogspot.com/2015/07/java-8-master-permutations.html
  *
  * @author Per Minborg
  */

--- a/src/main/java/net/openhft/chronicle/testframework/internal/CombinationUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/CombinationUtil.java
@@ -9,7 +9,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/src/main/java/net/openhft/chronicle/testframework/internal/PermutationUtil.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/PermutationUtil.java
@@ -9,7 +9,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
  * Utility methods for enumerating permutations. The algorithm maps the
  * permutation number to the factorial number system and selects elements one
  * by one. It was adapted from
- * http://minborgsjavapot.blogspot.com/2015/07/java-8-master-permutations.html
+ * https://minborgsjavapot.blogspot.com/2015/07/java-8-master-permutations.html
  *
  * Valid inputs are limited so that all factorial calculations fit within a
  * {@code long}. Collections larger than twenty items will therefore cause an

--- a/src/test/java/net/openhft/chronicle/testframework/internal/CombinationDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/CombinationDemoTest.java
@@ -9,7 +9,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/src/test/java/net/openhft/chronicle/testframework/internal/CombinationTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/CombinationTest.java
@@ -9,7 +9,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/src/test/java/net/openhft/chronicle/testframework/internal/PermutationDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/PermutationDemoTest.java
@@ -9,7 +9,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/src/test/java/net/openhft/chronicle/testframework/internal/PermutationTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/PermutationTest.java
@@ -9,7 +9,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/src/test/java/net/openhft/chronicle/testframework/internal/ProductDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/ProductDemoTest.java
@@ -9,7 +9,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/src/test/java/net/openhft/chronicle/testframework/internal/ProductTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/ProductTest.java
@@ -9,7 +9,7 @@
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT


### PR DESCRIPTION
## Summary
- Upgrades `http://` to `https://` in documentation files (.adoc, .md, LICENSE, NOTICE, AGENTS) and Java comment lines.
- Skips XML namespace identifiers (`xmlns=`, `xsi:schemaLocation=`) and non-comment Java source where a URL might be a literal value.
- Mechanical change, no code behaviour affected.

## Test plan
- [ ] Visual diff - only protocol `http` -> `https` changes.
- [ ] Spot-check a few upgraded links still resolve.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)