### PR TITLE
docs: replace retired maven-badges.herokuapp.com and dead search.maven.org URLs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 :toclevels: 2
 :icons: font
 
-image:https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-test-framework/badge.svg[Maven Central,link=https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-test-framework]
+image:https://img.shields.io/maven-central/v/net.openhft/chronicle-test-framework.svg[Maven Central,link=https://central.sonatype.com/artifact/net.openhft/chronicle-test-framework]
 image:https://javadoc.io/badge2/net.openhft/chronicle-test-framework/javadoc.svg[Javadoc,link="https://www.javadoc.io/doc/net.openhft/chronicle-test-framework/latest/index.html"]
 //image:https://javadoc-badge.appspot.com/net.openhft/chronicle-test-framework.svg?label=javadoc[JavaDoc, link=https://www.javadoc.io/doc/net.openhft/chronicle-test-framework]
 image:https://img.shields.io/github/license/OpenHFT/Chronicle-Test-Framework[Licence]


### PR DESCRIPTION
## Summary
- **Heroku retired free tier** so `maven-badges.herokuapp.com` is unreliable. Badges now point at `img.shields.io/maven-central/v/<group>/<artifact>.svg`.
- Badge/artifact links point at `central.sonatype.com/artifact/<group>/<artifact>` (the canonical Maven Central artifact page).
- Dead/clunky `search.maven.org/#search?g=...&a=...` URLs collapse to the same `central.sonatype.com/artifact/<g>/<a>` page.

## Test plan
- [ ] Click the Maven Central badge - should load a version.
- [ ] Click the artifact link - should land on Sonatype Central.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)