### PR TITLE
docs: convert narrative US spellings to UK English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ LLM-based agents can accelerate development only if they respect our house rules
 
 | Requirement  | Rationale |
 |--------------|-----------|
-| **British English** spelling (`organisation`, `licence`, *not* `organization`, `license`) except technical US spellings like `synchronized` | Keeps wording consistent with Chronicle's London HQ and existing docs. See the University of Oxford style guide for reference. |
+| **British English** spelling (`organisation`, `licence`, *not* `organisation`, `license`) except technical US spellings like `synchronized` | Keeps wording consistent with Chronicle's London HQ and existing docs. See the University of Oxford style guide for reference. |
 | **ASCII-7 only** (code-points 0-127). Avoid smart quotes, non-breaking spaces and accented characters. | ASCII-7 survives every toolchain Chronicle uses, incl. low-latency binary wire formats that expect the 8th bit to be 0. |
 | If you must show a symbol that does not exist in ASCII-7, spell it out (`micro-second`, `>=`, `:alpha:`, `:yes:`) rather than inserting Unicode. | Extended or '8-bit ASCII' variants are *not* portable and are therefore disallowed. |
 

--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -72,7 +72,7 @@ REQ-FR-CORE-003: Improved Assertion Capabilities ::
 REQ-FR-CORE-004: Formal Extensibility Model ::
 **Description:** Design and implement a formal extension model (e.g., inspired by JUnit 5's `@ExtendWith` or TestNG's listeners).
 **Rationale:** Foster broader adoption, enable community contributions, allow tailoring to specific project needs, and provide clear integration points for AI-generated code or custom analysis.
-**Possible Extensions:** Custom parameter resolvers, lifecycle callbacks, test instance post-processors, custom test execution behavior.
+**Possible Extensions:** Custom parameter resolvers, lifecycle callbacks, test instance post-processors, custom test execution behaviour.
 **Reference:** Research Sec 3.1.
 
 REQ-FR-CORE-005: TestNG Integration Support ::
@@ -106,7 +106,7 @@ REQ-FR-UX-002: Comprehensive Documentation and Illustrative Examples ::
 These requirements focus on providing specialized testing utilities for core OpenHFT libraries.
 
 REQ-FR-OHFT-001: Specialized Testing Utilities for Chronicle Queue ::
-**Description:** Develop utilities such as `TestAppender`, `TestTailer`, assertion helpers for message content, and utilities for programmatic setup/teardown of test queues. Include helpers for testing specific queue behaviors.
+**Description:** Develop utilities such as `TestAppender`, `TestTailer`, assertion helpers for message content, and utilities for programmatic setup/teardown of test queues. Include helpers for testing specific queue behaviours.
 **Rationale:** Simplify testing of Chronicle Queue, encapsulate common patterns, and reduce boilerplate.
 **Reference:** Research Sec 3.3.
 **Conceptual Example:**
@@ -161,7 +161,7 @@ REQ-FR-OHFT-003: Support for Chronicle Wire Serialization Testing ::
 **Reference:** Research Sec 3.3.
 
 REQ-FR-OHFT-004: Leveraging Chronicle Threads for Concurrency Testing ::
-**Description:** Offer utilities for managing `EventLoop` instances in tests, helpers for testing `Pauser` strategies, and assertions/patterns for verifying thread safety and concurrent behavior.
+**Description:** Offer utilities for managing `EventLoop` instances in tests, helpers for testing `Pauser` strategies, and assertions/patterns for verifying thread safety and concurrent behaviour.
 **Rationale:** Simplify the setup and verification of complex concurrent test scenarios.
 **Reference:** Research Sec 3.3.
 
@@ -197,7 +197,7 @@ REQ-FR-AI-002: Patterns for AI-Assisted Test Generation ::
 
 REQ-FR-AI-003: AI-Consumable API Design ::
 **Description:** All new CTF APIs (annotations, extension points, fluent builders, assertion methods) must be designed with AI consumption in mind, ensuring they are:
-* **Clearly Defined and Strongly Typed:** Minimize ambiguity, have clear contracts.
+* **Clearly Defined and Strongly Typed:** Minimise ambiguity, have clear contracts.
 * **Discoverable:** Comprehensive Javadoc, consistent naming, logical structure.
 * **Composable:** Designed as smaller, composable units of functionality.
 **Rationale:** Facilitate correct and effective use of CTF features by AI tools. Good API design for humans is critical for AI.
@@ -219,7 +219,7 @@ REQ-NFR-PERF-001: Performance of CTF ::
 **Reference:** User Doc "Suitability for Low-Latency and Performance-Critical Tests".
 
 *REQ-NFR-USAB-001: Usability and Learnability ::
-**Description:** The API should be intuitive, consistent, and easy to learn, particularly for developers familiar with Java and standard testing frameworks. The learning curve should be minimized.
+**Description:** The API should be intuitive, consistent, and easy to learn, particularly for developers familiar with Java and standard testing frameworks. The learning curve should be minimised.
 **Rationale:** Critical for adoption and effective use.
 **Reference:** User Doc "API Consistency and Learning Curve".
 
@@ -234,7 +234,7 @@ REQ-NFR-COMP-001: Compatibility ::
 **Reference:** CTF Current State, User Doc "Test Lifecycle and Configuration Ease".
 
 REQ-NFR-DOC-001: High-Quality Documentation ::
-**Description:** All features, APIs, extension points, and usage patterns must be thoroughly documented with clear examples. (Covered in REQ-FR-UX-002 but emphasized here as an NFR).
+**Description:** All features, APIs, extension points, and usage patterns must be thoroughly documented with clear examples. (Covered in REQ-FR-UX-002 but emphasised here as an NFR).
 **Rationale:** Essential for user adoption, understanding, and effective utilization.
 
 REQ-NFR-STAB-001: Stability and Versioning ::
@@ -247,7 +247,7 @@ REQ-NFR-STAB-001: Stability and Versioning ::
 The enhancement of CTF will proactively incorporate AI in two main ways:
 
 === 6.1. AI in the Development *of* CTF ===
-AI-DEV-CTF-001: Suggesting Refinements :: AI tools may be used to analyze the existing CTF codebase and the proposed APIs to suggest refinements, identify potential inconsistencies, or propose alternative designs based on common Java and testing framework patterns.
+AI-DEV-CTF-001: Suggesting Refinements :: AI tools may be used to analyse the existing CTF codebase and the proposed APIs to suggest refinements, identify potential inconsistencies, or propose alternative designs based on common Java and testing framework patterns.
 I-DEV-CTF-002: Boilerplate Code Generation :: For implementing well-defined, repetitive structures within CTF (e.g., new assertion methods following a pattern, boilerplate for new OpenHFT utility classes), AI can assist in generating initial code.
 AI-DEV-CTF-003: Documentation Assistance:** AI tools can help in generating Javadoc stubs, summarizing features for release notes, or even drafting initial sections of user guides based on code and requirements.
 
@@ -258,7 +258,7 @@ AI-APP-CTF-001: AI can understand CTF test structures :: Semantic annotations an
 AI-APP-CTF-002: AI can leverage CTF features for test generation :: AI tools can be guided to use CTF's data generators and OpenHFT-specific utilities to create more comprehensive and relevant tests.
 *  _Example:_ An AI agent, using `ChronicleQueueTestUtil` and `Permutation.of()`, could generate tests that try every ordering of different message types written to a queue, verifying that each ordering is processed correctly.
 I-APP-CTF-003: AI can assist in refactoring tests to use CTF :: As CTF evolves with more powerful utilities, AI can help migrate older tests (or tests not using CTF optimally) to leverage these new features, improving test quality and conciseness.
-AI-APP-CTF-004: AI can perform advanced test analysis :: With richer semantic information from CTF tests, AI might be able to perform more sophisticated analyses, such as identifying redundant tests, suggesting coverage improvements for specific OpenHFT behaviors, or even predicting flaky tests based on patterns.
+AI-APP-CTF-004: AI can perform advanced test analysis :: With richer semantic information from CTF tests, AI might be able to perform more sophisticated analyses, such as identifying redundant tests, suggesting coverage improvements for specific OpenHFT behaviours, or even predicting flaky tests based on patterns.
 
 By embedding AI considerations into the design of CTF, the framework will not only be improved by AI but will also empower its users to leverage AI for more effective testing within the OpenHFT ecosystem.
 

--- a/src/main/java/net/openhft/chronicle/testframework/FlakyTestRunner.java
+++ b/src/main/java/net/openhft/chronicle/testframework/FlakyTestRunner.java
@@ -55,7 +55,7 @@ public final class FlakyTestRunner {
 
         /**
          * Performs the action wrapping any thrown Throwable using the provided {@code exceptionMapper}.
-         * This allows customization of how exceptions should be handled and converted.
+         * This allows customisation of how exceptions should be handled and converted.
          *
          * @param exceptionMapper A function mapping a caught Throwable to a RuntimeException
          * @throws RuntimeException if an underlying Throwable is thrown
@@ -73,7 +73,7 @@ public final class FlakyTestRunner {
     /**
      * Creates a builder for constructing a flaky test runner for an action that might throw checked exceptions.
      * <p>
-     * The flaky test runner can be customized to handle various testing scenarios where a test may fail intermittently.
+     * The flaky test runner can be customised to handle various testing scenarios where a test may fail intermittently.
      *
      * @param action Action to perform, potentially throwing checked exceptions
      * @param <X>    Type of exception that can be thrown
@@ -193,14 +193,14 @@ public final class FlakyTestRunner {
         Builder<X> withErrorLogger(Consumer<? super String> errorLogger);
 
         /**
-         * Constructs a runnable object that encapsulates the configured flaky test behavior.
+         * Constructs a runnable object that encapsulates the configured flaky test behaviour.
          * <p>
          * This method finalizes the builder and constructs a new runnable object to handle
-         * the flaky test behavior based on the configured settings.
+         * the flaky test behaviour based on the configured settings.
          * <p>
          * This method can only be called once per builder instance.
          *
-         * @return A new RunnableThrows object that encapsulates the flaky test behavior
+         * @return A new RunnableThrows object that encapsulates the flaky test behaviour
          */
         RunnableThrows<X> build();
     }

--- a/src/main/java/net/openhft/chronicle/testframework/Permutation.java
+++ b/src/main/java/net/openhft/chronicle/testframework/Permutation.java
@@ -75,7 +75,7 @@ public final class Permutation {
         }
         // Check if the provided items list is null
         requireNonNull(items, "items must not be null");
-        // Utilize PermutationUtil to compute the permutation and return the result
+        // Utilise PermutationUtil to compute the permutation and return the result
         return PermutationUtil.permutation(no, items);
     }
 

--- a/src/main/java/net/openhft/chronicle/testframework/Product.java
+++ b/src/main/java/net/openhft/chronicle/testframework/Product.java
@@ -60,7 +60,7 @@ public final class Product {
         requireNonNull(ts, "The first collection (ts) must not be null");
         requireNonNull(us, "The second collection (us) must not be null");
 
-        // Utilize a helper method from ProductUtil to generate the Cartesian product and return as a stream
+        // Utilise a helper method from ProductUtil to generate the Cartesian product and return as a stream
         return of(ts, us, ProductUtil.Product2Impl::new);
     }
 
@@ -95,7 +95,7 @@ public final class Product {
         requireNonNull(us, "The second collection (us) must not be null");
         requireNonNull(constructor, "The constructor function must not be null");
 
-        // Utilize a helper method from ProductUtil to generate the Cartesian product and return as a stream
+        // Utilise a helper method from ProductUtil to generate the Cartesian product and return as a stream
         return ProductUtil.of(ts, us, constructor);
     }
 
@@ -308,7 +308,7 @@ public final class Product {
         /**
          * Applies this function to the given arguments, creating a result of type {@code R}.
          * <p>
-         * This functional interface is used to apply custom behavior to tuples within the cartesian
+         * This functional interface is used to apply custom behaviour to tuples within the cartesian
          * product, allowing for flexible creation of objects to represent those tuples.
          *
          * @param t the first function argument

--- a/src/main/java/net/openhft/chronicle/testframework/Waiters.java
+++ b/src/main/java/net/openhft/chronicle/testframework/Waiters.java
@@ -61,7 +61,7 @@ public class Waiters {
     }
 
     /**
-     * Creates a builder for waiting on a generic condition, allowing customization of the condition testing.
+     * Creates a builder for waiting on a generic condition, allowing customisation of the condition testing.
      * <p>
      * This method provides more flexibility for defining complex waiting conditions.
      *

--- a/src/main/java/net/openhft/chronicle/testframework/exception/ExceptionTracker.java
+++ b/src/main/java/net/openhft/chronicle/testframework/exception/ExceptionTracker.java
@@ -13,7 +13,7 @@ import java.util.function.Predicate;
 /**
  * The ExceptionTracker interface provides a set of methods to record, track, and assert exceptions
  * in a testing context. By defining rules to expect or ignore certain exceptions, it helps in
- * systematically verifying the correct exception handling behavior of code under test.
+ * systematically verifying the correct exception handling behaviour of code under test.
  *
  * @param <T> The class used to represent thrown exceptions
  */

--- a/src/main/java/net/openhft/chronicle/testframework/exception/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/exception/package-info.java
@@ -5,7 +5,7 @@
  * Provides classes and interfaces for tracking and asserting exceptions during testing.
  * This package includes utility interfaces and implementations that enable users to define
  * expected and ignored exceptions within testing scenarios, thereby facilitating the systematic
- * verification of correct exception handling behavior.
+ * verification of correct exception handling behaviour.
  *
  * @see net.openhft.chronicle.testframework.exception.ExceptionTracker
  */

--- a/src/main/java/net/openhft/chronicle/testframework/process/package-info.java
+++ b/src/main/java/net/openhft/chronicle/testframework/process/package-info.java
@@ -5,8 +5,8 @@
  * The {@code net.openhft.chronicle.testframework.internal.process} package provides internal implementations
  * for configuring and launching Java processes within the Chronicle testing framework.
  * <p>
- * This package includes classes that allow customization of JVM arguments, program arguments, classpath
- * entries, and IO behavior for spawned Java processes. It includes implementations of the
+ * This package includes classes that allow customisation of JVM arguments, program arguments, classpath
+ * entries, and IO behaviour for spawned Java processes. It includes implementations of the
  * {@link net.openhft.chronicle.testframework.process.JavaProcessBuilder} interface, providing control
  * over process creation.
  * <p>


### PR DESCRIPTION
## Summary
Documentation uses UK English for narrative text. Standard US technical terms (`synchronization`, `serialization`, `initialization`, `finalize`, `deserialize`, `normalization`) are preserved because that is how they appear in the Java platform and wider ecosystem.

Changes:
- `-or` -> `-our`: behavior, color, favor, flavor, honor, labor, neighbor, endeavor
- `-ize` -> `-ise` for non-technical verbs: organize, recognize, realize, optimize, minimize, maximize, emphasize, utilize, summarize, customize, prioritize, generalize, analyze

Proper nouns (e.g. "Apache License") and third-party paths (e.g. `jsr166/`) are left alone.

## Test plan
- [ ] Diff shows only narrative/spelling swaps.
- [ ] No API or identifier names affected.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)