### PR TITLE
Fix exception tracker races and reset handlers on failure

### DIFF
--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -178,6 +178,20 @@ REQ-FR-OHFT-006: Resource and Concurrency Test Utilities ::
 **Rationale:** Address common pain points in testing high-performance, resource-intensive applications and ensure test reliability.
 **Reference:** User Doc "Opportunities for Improvement - Resource and Concurrency Utilities".
 
+CTF-FN-001: Exception-check snapshot and cleanup ::
+Concurrent recording must not invalidate exception inspection, filtering or failure diagnostics.
+Each check uses one detached snapshot, with callbacks outside the recording map's monitor.
+Recorders must use that same monitor, for example through `Collections.synchronizedMap`.
+Producers must be stopped/joined before the check when their complete output must be included; late records are outside its snapshot.
+Filtering must not erase a later repeat whose count differs from the captured count.
+The first check must always reset handlers, including on missing expectations, unexpected exceptions and callback failures.
+A reset failure must not mask an earlier failure, and the tracker remains single-use after any outcome.
+Evidence: `VanillaExceptionTrackerTest#concurrentRecordingDuringRenderingUsesOneSnapshot`,
+`#concurrentRecordingDuringPredicateDoesNotMutateTraversal`, `#filteringPreservesRepeatsRecordedAfterTheSnapshot`,
+`#snapshotCopiesEntriesWhileHoldingRecordingMonitor`,
+`#missingExpectationStillResetsHandlers`, `#unexpectedExceptionStillResetsHandlers` and
+`#renderingFailureIsPreservedWhenResetAlsoFails`.
+
 === 4.4. AI-Specific Functional Requirements ===
 
 These requirements are specifically aimed at designing CTF to effectively leverage and support AI tools.
@@ -264,4 +278,10 @@ By embedding AI considerations into the design of CTF, the framework will not on
 
 == 7. Conclusion ==
 
-The Chronicle Test Framework has a solid foundation in test data generation. By implementing the requirements outlined in this document, CTF will evolve into a more comprehensive, user-friendly, and powerful testing tool, especially for the OpenHFT ecosystem. The strategic incorporation of AI-support features will position CTF as a forward-looking framework, enabling new levels of efficiency and intelligence in software testing. The key is to build upon its unique strengths while addressing current limitations and embracing modern testing paradigms, all while ensuring it remains a valuable complement to mainstream testing frameworks.
+The Chronicle Test Framework has a solid foundation in test data generation.
+By implementing the requirements outlined in this document, CTF will evolve into a more comprehensive, user-friendly,
+and powerful testing tool, especially for the OpenHFT ecosystem.
+The strategic incorporation of AI-support features will position CTF as a forward-looking framework,
+enabling new levels of efficiency and intelligence in software testing.
+The key is to build upon its unique strengths while addressing current limitations and embracing modern testing paradigms,
+all while ensuring it remains a valuable complement to mainstream testing frameworks.

--- a/src/main/java/net/openhft/chronicle/testframework/exception/ExceptionTracker.java
+++ b/src/main/java/net/openhft/chronicle/testframework/exception/ExceptionTracker.java
@@ -22,10 +22,12 @@ public interface ExceptionTracker<T> {
     /**
      * Factory method to create an instance of the exception tracker. This method encapsulates
      * the construction of a concrete implementation of the ExceptionTracker interface.
+     * Concurrent recorders must synchronise on the supplied map, for example by using
+     * {@link java.util.Collections#synchronizedMap(Map)}. Tracker configuration and checks are single-threaded.
      *
      * @param messageExtractor   Function to extract the String message or description from T
      * @param throwableExtractor Function to extract the Throwable from T
-     * @param resetRunnable      Runnable that will be called at the end of {@link #checkExceptions()}
+     * @param resetRunnable      called once when the first check finishes, including on assertion or callback failure
      * @param exceptions         Map to populate with T as the key and count of occurrences as value
      * @param ignorePredicate    Predicate to exclude T's from consideration
      * @param exceptionRenderer  Function to render T as a String (used when dumping exceptions)
@@ -103,6 +105,10 @@ public interface ExceptionTracker<T> {
      *     <li>Assert there is an exception matching each of the expected predicates</li>
      * </ul>
      * Implementations should throw an exception and print a summary if the assertion(s) are violated.
+     * The default implementation checks one snapshot taken at the start of this call, invoking predicates and renderers
+     * without holding the recording map's monitor. Stop/join producers before checking when all their records must be included.
+     * Matched entries are removed from the live map only if their counts still match the snapshot; later repeats are retained.
+     * Reset still runs on failure, with any reset failure suppressed on the original exception rather than replacing it.
      */
     void checkExceptions();
 }

--- a/src/main/java/net/openhft/chronicle/testframework/internal/VanillaExceptionTracker.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/VanillaExceptionTracker.java
@@ -116,7 +116,7 @@ public final class VanillaExceptionTracker<T> implements ExceptionTracker<T> {
                 resetRunnable.run();
             } catch (RuntimeException | Error resetFailure) {
                 //! #renderingFailureIsPreservedWhenResetAlsoFails preserves the diagnostic failure instead of masking it with cleanup.
-                //! #resetFailureAfterSuccessfulCheckIsPropagated is integration evidence for the existing successful-check behaviour.
+                //! #resetFailureAfterSuccessfulCheckIsPropagated is preservation evidence for the existing successful-check behaviour.
                 if (failure == null)
                     throw resetFailure;
                 if (failure != resetFailure)

--- a/src/main/java/net/openhft/chronicle/testframework/internal/VanillaExceptionTracker.java
+++ b/src/main/java/net/openhft/chronicle/testframework/internal/VanillaExceptionTracker.java
@@ -91,34 +91,81 @@ public final class VanillaExceptionTracker<T> implements ExceptionTracker<T> {
 
     @Override
     public boolean hasException(Predicate<T> predicate) {
-        return exceptions.keySet().stream().anyMatch(predicate);
+        return snapshot().keySet().stream().anyMatch(predicate);
     }
 
     @Override
     public boolean hasException(String message) {
-        return exceptions.keySet().stream().anyMatch(k -> containsString(k, message));
+        return hasException(k -> containsString(k, message));
     }
 
     @Override
     public void checkExceptions() {
         checkFinalised();
         finalised = true;
+        Throwable failure = null;
+        try {
+            checkExceptions(snapshot());
+        } catch (RuntimeException | Error e) {
+            failure = e;
+            throw e;
+        } finally {
+            //! VanillaExceptionTrackerTest#missingExpectationStillResetsHandlers and #unexpectedExceptionStillResetsHandlers
+            //! prevent a failed test from retaining recording handlers into the next test. Reset on success alone misses both paths.
+            try {
+                resetRunnable.run();
+            } catch (RuntimeException | Error resetFailure) {
+                //! #renderingFailureIsPreservedWhenResetAlsoFails preserves the diagnostic failure instead of masking it with cleanup.
+                //! #resetFailureAfterSuccessfulCheckIsPropagated is integration evidence for the existing successful-check behaviour.
+                if (failure == null)
+                    throw resetFailure;
+                if (failure != resetFailure)
+                    failure.addSuppressed(resetFailure);
+            }
+        }
+    }
+
+    private void checkExceptions(Map<T, Integer> snapshot) {
         for (Map.Entry<Predicate<T>, String> expectedException : expectedExceptions.entrySet()) {
-            if (!exceptions.keySet().removeIf(expectedException.getKey()))
+            if (!removeMatching(snapshot, expectedException.getKey()))
                 throw new AssertionError("No error for " + expectedException.getValue());
         }
         for (Map.Entry<Predicate<T>, String> ignoredException : ignoredExceptions.entrySet()) {
-            if (exceptions.keySet().removeIf(ignoredException.getKey()))
+            if (removeMatching(snapshot, ignoredException.getKey()))
                 LOGGER.debug("Ignored {}", ignoredException.getValue());
         }
 
-        if (hasExceptions()) {
-            dumpException();
+        if (hasExceptions(snapshot)) {
+            dumpException(snapshot);
 
-            final String msg = exceptions.size() + " exceptions were detected: " + exceptions.keySet().stream().map(messageExtractor::apply).collect(Collectors.joining(", "));
+            final String msg = snapshot.size() + " exceptions were detected: "
+                    + snapshot.keySet().stream().map(messageExtractor::apply).collect(Collectors.joining(", "));
             throw new AssertionError(msg);
         }
-        resetRunnable.run();
+    }
+
+    private Map<T, Integer> snapshot() {
+        //! VanillaExceptionTrackerTest#concurrentRecordingDuringRenderingUsesOneSnapshot prevents a late recording from invalidating
+        //! diagnostic iteration or changing its summary. #snapshotCopiesEntriesWhileHoldingRecordingMonitor checks the copy's lock:
+        //! a synchronizedMap does not synchronise its iterators on its own.
+        //! #concurrentRecordingDuringPredicateDoesNotMutateTraversal also requires callbacks outside the map lock, so a callback can
+        //! wait for a recording worker without deadlock. One detached copy supplies all phases of a check, including the repeat counts.
+        synchronized (exceptions) {
+            return new LinkedHashMap<>(exceptions);
+        }
+    }
+
+    private boolean removeMatching(Map<T, Integer> snapshot, Predicate<T> predicate) {
+        return snapshot.entrySet().removeIf(entry -> {
+            if (!predicate.test(entry.getKey()))
+                return false;
+            //! #filteringPreservesRepeatsRecordedAfterTheSnapshot exercises a late repeat while filtering. Preserve records
+            //! whose counts changed after the snapshot; unconditional removal would erase those later observations from the live map.
+            synchronized (exceptions) {
+                exceptions.remove(entry.getKey(), entry.getValue());
+            }
+            return true;
+        });
     }
 
     /**
@@ -175,8 +222,8 @@ public final class VanillaExceptionTracker<T> implements ExceptionTracker<T> {
      * Determines whether any recorded exceptions remain after applying the
      * ignore predicate.
      */
-    private boolean hasExceptions() {
-        for (T k : exceptions.keySet()) {
+    private boolean hasExceptions(Map<T, Integer> snapshot) {
+        for (T k : snapshot.keySet()) {
             if (!ignorePredicate.test(k))
                 return true;
         }
@@ -188,8 +235,8 @@ public final class VanillaExceptionTracker<T> implements ExceptionTracker<T> {
      * Logs all remaining exceptions and their repeat counts. Used when the
      * test is about to fail.
      */
-    private void dumpException() {
-        for (@NotNull Map.Entry<T, Integer> entry : exceptions.entrySet()) {
+    private void dumpException(Map<T, Integer> snapshot) {
+        for (@NotNull Map.Entry<T, Integer> entry : snapshot.entrySet()) {
             final T key = entry.getKey();
             LOGGER.warn(exceptionRenderer.apply(key), throwableExtractor.apply(key));
             final Integer value = entry.getValue();

--- a/src/test/java/net/openhft/chronicle/testframework/internal/VanillaExceptionTrackerTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/VanillaExceptionTrackerTest.java
@@ -5,9 +5,16 @@ package net.openhft.chronicle.testframework.internal;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractSet;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -156,21 +163,37 @@ class VanillaExceptionTrackerTest {
     }
 
     @Test
-    void concurrentRecordingDuringRenderingUsesOneSnapshot() throws InterruptedException {
+    @ResourceLock(Resources.SYSTEM_ERR)
+    void concurrentRecordingDuringRenderingUsesOneSnapshot() throws Exception {
         Map<String, Integer> counts = Collections.synchronizedMap(new LinkedHashMap<>());
         counts.put("first", 1);
         counts.put("second", 2);
         ExecutorService writer = Executors.newSingleThreadExecutor();
-        try {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (PrintStream captured = new PrintStream(output, true, StandardCharsets.UTF_8.name())) {
             VanillaExceptionTracker<String> tracker = new VanillaExceptionTracker<>(s -> s, s -> null,
                     resetCounter::incrementAndGet, counts, s -> false, s -> {
                         if ("first".equals(s))
-                            recordOnWorker(writer, counts);
+                            recordOnWorker(writer, () -> {
+                                counts.merge("late", 1, Integer::sum);
+                                counts.merge("second", 10, Integer::sum);
+                            });
                         return s;
                     });
-            AssertionError failure = assertThrows(AssertionError.class, tracker::checkExceptions);
+            PrintStream original = System.err;
+            AssertionError failure;
+            try {
+                System.setErr(captured);
+                failure = assertThrows(AssertionError.class, tracker::checkExceptions);
+            } finally {
+                System.setErr(original);
+            }
             assertEquals("2 exceptions were detected: first, second", failure.getMessage());
             assertEquals(3, counts.size());
+            assertEquals(Integer.valueOf(12), counts.get("second"));
+            String diagnostics = new String(output.toByteArray(), StandardCharsets.UTF_8);
+            assertTrue(diagnostics.contains("Repeated 2 times"), diagnostics);
+            assertFalse(diagnostics.contains("Repeated 12 times"), diagnostics);
             assertEquals(1, resetCounter.get());
         } finally {
             writer.shutdownNow();
@@ -188,11 +211,11 @@ class VanillaExceptionTrackerTest {
             VanillaExceptionTracker<String> tracker = new VanillaExceptionTracker<>(s -> s, s -> null,
                     resetCounter::incrementAndGet, counts, s -> false);
             assertFalse(tracker.hasException(s -> {
-                recordOnWorker(writer, counts);
+                recordOnWorker(writer, () -> counts.merge("late", 1, Integer::sum));
                 return false;
             }));
             tracker.expectException(s -> {
-                recordOnWorker(writer, counts);
+                recordOnWorker(writer, () -> counts.merge("late", 1, Integer::sum));
                 return "first".equals(s);
             }, "first");
             tracker.ignoreException(s -> true, "remaining");
@@ -204,9 +227,9 @@ class VanillaExceptionTrackerTest {
         }
     }
 
-    private static void recordOnWorker(ExecutorService writer, Map<String, Integer> counts) {
+    private static void recordOnWorker(ExecutorService writer, Runnable record) {
         try {
-            writer.submit(() -> counts.merge("late", 1, Integer::sum)).get(2, TimeUnit.SECONDS);
+            writer.submit(record).get(2, TimeUnit.SECONDS);
         } catch (Exception e) {
             throw new AssertionError("Recording must not be blocked by a tracker callback", e);
         }
@@ -238,10 +261,37 @@ class VanillaExceptionTrackerTest {
     @Test
     void snapshotCopiesEntriesWhileHoldingRecordingMonitor() {
         Map<String, Integer> counts = new LinkedHashMap<String, Integer>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public Set<Map.Entry<String, Integer>> entrySet() {
                 assertTrue(Thread.holdsLock(this), "Copying live entries must use the recorders' monitor");
-                return super.entrySet();
+                Map<String, Integer> recordingMap = this;
+                Set<Map.Entry<String, Integer>> entries = super.entrySet();
+                return new AbstractSet<Map.Entry<String, Integer>>() {
+                    @Override
+                    public Iterator<Map.Entry<String, Integer>> iterator() {
+                        Iterator<Map.Entry<String, Integer>> delegate = entries.iterator();
+                        return new Iterator<Map.Entry<String, Integer>>() {
+                            @Override
+                            public boolean hasNext() {
+                                assertTrue(Thread.holdsLock(recordingMap), "Iterator.hasNext must use the recorders' monitor");
+                                return delegate.hasNext();
+                            }
+
+                            @Override
+                            public Map.Entry<String, Integer> next() {
+                                assertTrue(Thread.holdsLock(recordingMap), "Iterator.next must use the recorders' monitor");
+                                return delegate.next();
+                            }
+                        };
+                    }
+
+                    @Override
+                    public int size() {
+                        return entries.size();
+                    }
+                };
             }
         };
         counts.put("expected", 1);

--- a/src/test/java/net/openhft/chronicle/testframework/internal/VanillaExceptionTrackerTest.java
+++ b/src/test/java/net/openhft/chronicle/testframework/internal/VanillaExceptionTrackerTest.java
@@ -6,8 +6,14 @@ package net.openhft.chronicle.testframework.internal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -109,6 +115,141 @@ class VanillaExceptionTrackerTest {
     @Test
     void resetRunnableIsCalledInCheck() {
         vet.checkExceptions();
+        assertEquals(1, resetCounter.get());
+    }
+
+    @Test
+    void missingExpectationStillResetsHandlers() {
+        vet.expectException("missing");
+        assertThrows(AssertionError.class, vet::checkExceptions);
+        assertEquals(1, resetCounter.get());
+        assertThrows(IllegalStateException.class, vet::checkExceptions);
+        assertEquals(1, resetCounter.get());
+    }
+
+    @Test
+    void unexpectedExceptionStillResetsHandlers() {
+        exceptionCounts.put(new ExceptionHolder("unexpected", null, false), 1);
+        AssertionError failure = assertThrows(AssertionError.class, vet::checkExceptions);
+        assertEquals("1 exceptions were detected: unexpected", failure.getMessage());
+        assertEquals(1, resetCounter.get());
+    }
+
+    @Test
+    void renderingFailureIsPreservedWhenResetAlsoFails() {
+        IllegalStateException renderingFailure = new IllegalStateException("renderer failed");
+        AssertionError resetFailure = new AssertionError("reset failed");
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        counts.put("unexpected", 1);
+        VanillaExceptionTracker<String> tracker = new VanillaExceptionTracker<>(s -> s, s -> null,
+                () -> { throw resetFailure; }, counts, s -> false, s -> { throw renderingFailure; });
+        assertSame(renderingFailure, assertThrows(IllegalStateException.class, tracker::checkExceptions));
+        assertArrayEquals(new Throwable[]{resetFailure}, renderingFailure.getSuppressed());
+    }
+
+    @Test
+    void resetFailureAfterSuccessfulCheckIsPropagated() {
+        IllegalStateException resetFailure = new IllegalStateException("reset failed");
+        VanillaExceptionTracker<String> tracker = new VanillaExceptionTracker<>(s -> s, s -> null,
+                () -> { throw resetFailure; }, new HashMap<>(), s -> false);
+        assertSame(resetFailure, assertThrows(IllegalStateException.class, tracker::checkExceptions));
+    }
+
+    @Test
+    void concurrentRecordingDuringRenderingUsesOneSnapshot() throws InterruptedException {
+        Map<String, Integer> counts = Collections.synchronizedMap(new LinkedHashMap<>());
+        counts.put("first", 1);
+        counts.put("second", 2);
+        ExecutorService writer = Executors.newSingleThreadExecutor();
+        try {
+            VanillaExceptionTracker<String> tracker = new VanillaExceptionTracker<>(s -> s, s -> null,
+                    resetCounter::incrementAndGet, counts, s -> false, s -> {
+                        if ("first".equals(s))
+                            recordOnWorker(writer, counts);
+                        return s;
+                    });
+            AssertionError failure = assertThrows(AssertionError.class, tracker::checkExceptions);
+            assertEquals("2 exceptions were detected: first, second", failure.getMessage());
+            assertEquals(3, counts.size());
+            assertEquals(1, resetCounter.get());
+        } finally {
+            writer.shutdownNow();
+            assertTrue(writer.awaitTermination(2, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void concurrentRecordingDuringPredicateDoesNotMutateTraversal() throws InterruptedException {
+        Map<String, Integer> counts = Collections.synchronizedMap(new LinkedHashMap<>());
+        counts.put("first", 1);
+        counts.put("second", 2);
+        ExecutorService writer = Executors.newSingleThreadExecutor();
+        try {
+            VanillaExceptionTracker<String> tracker = new VanillaExceptionTracker<>(s -> s, s -> null,
+                    resetCounter::incrementAndGet, counts, s -> false);
+            assertFalse(tracker.hasException(s -> {
+                recordOnWorker(writer, counts);
+                return false;
+            }));
+            tracker.expectException(s -> {
+                recordOnWorker(writer, counts);
+                return "first".equals(s);
+            }, "first");
+            tracker.ignoreException(s -> true, "remaining");
+            tracker.checkExceptions();
+            assertEquals(1, resetCounter.get());
+        } finally {
+            writer.shutdownNow();
+            assertTrue(writer.awaitTermination(2, TimeUnit.SECONDS));
+        }
+    }
+
+    private static void recordOnWorker(ExecutorService writer, Map<String, Integer> counts) {
+        try {
+            writer.submit(() -> counts.merge("late", 1, Integer::sum)).get(2, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new AssertionError("Recording must not be blocked by a tracker callback", e);
+        }
+    }
+
+    @Test
+    void filteringPreservesRepeatsRecordedAfterTheSnapshot() {
+        Map<String, Integer> counts = Collections.synchronizedMap(new LinkedHashMap<>());
+        counts.put("expected", 1);
+        counts.put("ignored", 1);
+        VanillaExceptionTracker<String> tracker = new VanillaExceptionTracker<>(s -> s, s -> null,
+                resetCounter::incrementAndGet, counts, s -> false);
+        tracker.expectException(s -> {
+            if (!"expected".equals(s))
+                return false;
+            counts.merge(s, 1, Integer::sum);
+            return true;
+        }, "expected");
+        tracker.ignoreException(s -> {
+            counts.merge(s, 1, Integer::sum);
+            return true;
+        }, "ignored");
+        tracker.checkExceptions();
+        assertEquals(Integer.valueOf(2), counts.get("expected"));
+        assertEquals(Integer.valueOf(2), counts.get("ignored"));
+        assertEquals(1, resetCounter.get());
+    }
+
+    @Test
+    void snapshotCopiesEntriesWhileHoldingRecordingMonitor() {
+        Map<String, Integer> counts = new LinkedHashMap<String, Integer>() {
+            @Override
+            public Set<Map.Entry<String, Integer>> entrySet() {
+                assertTrue(Thread.holdsLock(this), "Copying live entries must use the recorders' monitor");
+                return super.entrySet();
+            }
+        };
+        counts.put("expected", 1);
+        VanillaExceptionTracker<String> tracker = new VanillaExceptionTracker<>(s -> s, s -> null,
+                resetCounter::incrementAndGet, counts, s -> false);
+        assertTrue(tracker.hasException("expected"));
+        tracker.expectException("expected");
+        tracker.checkExceptions();
         assertEquals(1, resetCounter.get());
     }
 


### PR DESCRIPTION
## Why

Triage of Queue's 32-bit Java 17/21 suite exposed an independent test-framework failure:
late resource warnings can modify the recorded-exception map while diagnostics iterate it,
replacing the useful failure with `ConcurrentModificationException`. The reset callback
previously ran only on success, leaving recording handlers installed after a failed check.

## Changes

- Take one monitor-protected snapshot for each check; use it for filtering, repeat counts and diagnostics.
- Run predicates and renderers outside the recording monitor so they can wait for a recording worker safely.
- Keep live-map removal of expected/ignored entries, but retain later repeats whose counts have changed.
- Reset once after the first check, on success or failure. Preserve the original exception if reset also fails.
- Document the snapshot boundary: callers must stop/join producers before checking to include all their output.
- Add eight focused regressions and adjacent `//!` evidence. No log/leak checks are disabled.

## Review follow-up

- Add `serialVersionUID` to the anonymous map fixture. The supplied Windows Java 8 log at `8bac5ea278b27cb5f15211d6e0e07895c1590977` fails test compilation on this missing field with `-Werror`; the exact warning was reproduced locally on Java 8. No warning suppression or compiler relaxation is added.
- During rendering, a worker adds a late entry and increases the live repeat count from 2 to 12. Capture the real SLF4J Simple diagnostics and require `Repeated 2 times`, not 12. Restore `System.err` in `finally`, with a Jupiter resource lock for the capture.
- Check the recording monitor inside both iterator `hasNext()` and `next()`, not just when obtaining `entrySet()`.
- Correct the successful-reset comment from integration evidence to preservation evidence. Production behaviour, dependencies and public APIs are unchanged by this follow-up.

## Validation

Fresh full `mvn -B -nsu clean verify -Dsurefire.rerunFailingTestsCount=0` on Linux at `ee07d60bbc5121acdee6b7fc8eb4c30fd3156f5c`:

| JVM | Tests | Failures/errors/skips |
| --- | ---: | --- |
| OpenJDK 8u502, 64-bit | 794 | 0 / 0 / 0 |
| OpenJDK 17.0.20, 64-bit | 794 | 0 / 0 / 0 |
| OpenJDK 21.0.12, 64-bit | 794 | 0 / 0 / 0 |

Before the implementation, five of the first six new regressions failed against `develop`,
including the deterministic concurrent-rendering case with `ConcurrentModificationException`.
The successful-check reset case is preservation evidence, not a base discriminator.
Additional tests cover preservation of late repeat counts and the snapshot's recording monitor.
`git diff --check` and the 144-character check for added lines pass.

The stronger tests were also checked against three isolated production-source mutations using the actual Maven/Jupiter suite on Java 8, without stubs or new dependencies:

| Deliberate fault | Previous tests plus Java 8 serial-field fix | Strengthened tests |
| --- | --- | --- |
| Diagnostics read repeat counts from the live map | Pass | Fail: diagnostic reports 12 instead of 2 |
| Obtain the entry view under the monitor, then traverse outside it | Pass | Fail: `Iterator.hasNext` lacks the monitor |
| Obtain the iterator and call `hasNext` under the monitor, but call `next` outside | Pass | Fail: `Iterator.next` lacks the monitor |

All three failures were assertion failures after successful compilation, not compilation errors counted as mutation detections. The unmodified production implementation passes all three full verification runs above.

## CI disposition

The reviewed head `8bac5ea278b27cb5f15211d6e0e07895c1590977` had four failing contexts: Windows, Linux Java 8, Zing Java 8 and Linux ARM. The Windows excerpt establishes the serial-field compilation defect; local Linux Java 8 reproduces the same failure before the fix. The other three historical job logs could not be retrieved because TeamCity guest REST and build-log access return HTTP 401; they have been requested. Their exact causes are not claimed as established.

The updated head needs fresh platform CI. Hold merging until the non-informational failures are resolved or supported by an explicit disposition. Java 26+ results are informational; passing local tests does not establish Windows, ARM or Zing results.

## Scope

Based directly on `develop` at `ac91cfc0c99c80050def35ab50c3ca976d0aa34e`.
This is independent of Queue's feature stack. The companion
[Chronicle-Queue #1756](https://github.com/OpenHFT/Chronicle-Queue/pull/1756) fixes mapping configuration,
store-acquisition ownership and fixture cleanup without pinning an unreleased test-framework dependency.
Platform CI remains a separate merge gate; the results above are local runs.
